### PR TITLE
Add the Windows GPU executor

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,21 +1,28 @@
 version: 2.1
 description: "A set of tools convenient for running Windows jobs on CircleCI."
+
+## Anchors (used to DRY the executors in this orb)
+base-shell: &base-shell
+  type: string
+  description: >
+    The shell to use.
+    Defaults to `powershell.exe -ExecutionPolicy Bypass`
+  default: powershell.exe -ExecutionPolicy Bypass
+
+base-version: &base-version
+  type: string
+  description: The image version to use when executing. Defaults to "stable".
+  default: "stable"
+
+## Executors (for use in config)
 executors:
   default:
     description: >
       An executor preloaded with Visual Studio 2019 plus a number of other
       development tools.
     parameters:
-      version:
-        type: string
-        description: The image version to use when executing. Defaults to "stable".
-        default: "stable"
-      shell:
-        type: string
-        description: >
-          The shell to use.
-          Defaults to `powershell.exe -ExecutionPolicy Bypass`
-        default: powershell.exe -ExecutionPolicy Bypass
+      version: *base-version
+      shell: *base-shell
       size:
         type: enum
         description: >
@@ -33,22 +40,13 @@ executors:
       An executor with an Nvidia GPU which includes a pre-installed CUDA
       runtime and the cuDNN library.
     parameters:
-      version:
-        type: string
-        description: The image version to use when executing. Defaults to "stable".
-        default: "stable"
-      shell:
-        type: string
-        description: >
-          The shell to use.
-          Defaults to `powershell.exe -ExecutionPolicy Bypass`
-        default: powershell.exe -ExecutionPolicy Bypass
+      version: *base-version
+      shell: *base-shell
       size:
         type: enum
         description: >
           The size of Windows GPU resource to use.
-          Defaults to medium, which resolves to the full name
-          windows.gpu.nvidia.medium.
+          Defaults to medium.
         default: "medium"
         enum: ["medium"]
     machine:


### PR DESCRIPTION
Considerations:

* `gpu-nvidia` as the executor name as the "nvidia" part is important — using an Nvidia GPU and an AMD GPU is quite different. We are committing to always provide an Nvidia GPU for this resource (but not committing to a specific GPU model).