### PR TITLE
Updating default to use 'current' instead of 'edge' or 'stable' [semver:minor] 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,18 +73,18 @@ workflows:
           matrix:
             parameters:
               variant: [vs2019]
-              version: [stable, edge]
+              version: [edge, current]
       - test-server-2019-cuda:
           name: test-server-2019-cuda-<< matrix.version >>
           matrix:
             parameters:
-              version: [edge]
+              version: [edge, current]
       - test-server-2022:
           name: test-server-2022-<< matrix.variant >>-<< matrix.version >>
           matrix:
             parameters:
               variant: [gui] # add core when available
-              version: [edge] # add stable when available
+              version: [edge, current] # add stable when available
       - orb-tools/dev-promote-prod-from-commit-subject:
           name: dev-promote-semver
           add-pr-comment: true

--- a/src/examples/run_default.yml
+++ b/src/examples/run_default.yml
@@ -2,7 +2,7 @@ description: This is an example of running a simple job on the default Windows e
 usage:
     version: 2.1
     orbs:
-        win: circleci/windows@4.0
+        win: circleci/windows@4.1
     jobs:
         build:
             executor:

--- a/src/examples/run_windows_2019.yml
+++ b/src/examples/run_windows_2019.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    win: circleci/windows@4.0
+    win: circleci/windows@4.1
   jobs:
     build:
       executor: win/server-2019

--- a/src/examples/run_windows_2019_cuda.yml
+++ b/src/examples/run_windows_2019_cuda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    win: circleci/windows@4.0
+    win: circleci/windows@4.1
   jobs:
     build:
       executor: win/server-2019-cuda

--- a/src/examples/run_windows_2022.yml
+++ b/src/examples/run_windows_2022.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    win: circleci/windows@4.0
+    win: circleci/windows@4.1
   jobs:
     build:
       executor: win/server-2022

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -23,7 +23,7 @@ parameters:
       - vs2019
     type: enum
   version:
-    default: stable
+    default: current
     description: The image version to use when executing. Defaults to "stable".
     type: string
 

--- a/src/executors/server-2019-cuda.yml
+++ b/src/executors/server-2019-cuda.yml
@@ -16,7 +16,7 @@ parameters:
       - large
     type: enum
   version:
-    default: stable
+    default: current
     description: The image version to use when executing. Defaults to "stable".
     type: string
 

--- a/src/executors/server-2019.yml
+++ b/src/executors/server-2019.yml
@@ -23,7 +23,7 @@ parameters:
       - vs2019
     type: enum
   version:
-    default: stable
+    default: current
     description: The image version to use when executing. Defaults to "stable".
     type: string
 

--- a/src/executors/server-2022.yml
+++ b/src/executors/server-2022.yml
@@ -23,7 +23,7 @@ parameters:
       - gui
     type: enum
   version:
-    default: edge
+    default: current
     description: The image version to use when executing. Defaults to "edge".
     type: string
 


### PR DESCRIPTION
Updating defaults to use 'current'  instead of 'edge' or 'stable'. If no tag is specified then 'current' will be used.