### PR TITLE
fea: set windows server 2022 as default

### DIFF
--- a/src/examples/run_default.yml
+++ b/src/examples/run_default.yml
@@ -1,16 +1,16 @@
 description: This is an example of running a simple job on the default Windows executor
 usage:
-    version: 2.1
-    orbs:
-        win: circleci/windows@4.1
-    jobs:
-        build:
-            executor:
-                name: win/default
-            steps:
-                - checkout
-                - run: Write-Host 'Hello, Windows'
-    workflows:
-        my-workflow:
-            jobs:
-                - build
+  version: 2.1
+  orbs:
+    win: circleci/windows@4.2
+  jobs:
+    build:
+      executor:
+        name: win/default
+      steps:
+        - checkout
+        - run: Write-Host 'Hello, Windows'
+  workflows:
+    my-workflow:
+      jobs:
+        - build

--- a/src/examples/run_windows_2019.yml
+++ b/src/examples/run_windows_2019.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    win: circleci/windows@4.1
+    win: circleci/windows@4.2
   jobs:
     build:
       executor: win/server-2019

--- a/src/examples/run_windows_2019_cuda.yml
+++ b/src/examples/run_windows_2019_cuda.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    win: circleci/windows@4.1
+    win: circleci/windows@4.2
   jobs:
     build:
       executor: win/server-2019-cuda

--- a/src/examples/run_windows_2022.yml
+++ b/src/examples/run_windows_2022.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    win: circleci/windows@4.1
+    win: circleci/windows@4.2
   jobs:
     build:
       executor: win/server-2022

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,5 +1,5 @@
 description: >
-  An executor preloaded with Visual Studio 2019 plus a number of other
+  An executor preloaded with Visual Studio 2022 plus a number of other
   development tools.
 
 parameters:
@@ -12,15 +12,12 @@ parameters:
     description: 'The size of Windows resource to use. Defaults to medium.'
     enum:
       - medium
-      - large
-      - xlarge
-      - 2xlarge
     type: enum
   variant:
-    default: vs2019
-    description: 'The variant of windows 2019. Defaults to vs2019.'
+    default: gui
+    description: 'The variant of windows server 2022. Defaults to gui.'
     enum:
-      - vs2019
+      - gui
     type: enum
   version:
     default: current
@@ -28,6 +25,6 @@ parameters:
     type: string
 
 machine:
-  image: windows-server-2019-<< parameters.variant >>:<< parameters.version >>
+  image: windows-server-2022-<< parameters.variant >>:<< parameters.version >>
   resource_class: windows.<< parameters.size >>
   shell: << parameters.shell >>

--- a/src/executors/server-2019-cuda.yml
+++ b/src/executors/server-2019-cuda.yml
@@ -11,9 +11,7 @@ parameters:
     default: medium
     description: 'The size of Windows GPU resource to use. Defaults to medium.'
     enum:
-      - small
       - medium
-      - large
     type: enum
   version:
     default: current

--- a/src/executors/server-2019.yml
+++ b/src/executors/server-2019.yml
@@ -12,9 +12,6 @@ parameters:
     description: 'The size of Windows resource to use. Defaults to medium.'
     enum:
       - medium
-      - large
-      - xlarge
-      - 2xlarge
     type: enum
   variant:
     default: vs2019

--- a/src/executors/server-2022.yml
+++ b/src/executors/server-2022.yml
@@ -12,9 +12,6 @@ parameters:
     description: 'The size of Windows resource to use. Defaults to medium.'
     enum:
       - medium
-      - large
-      - xlarge
-      - 2xlarge
     type: enum
   variant:
     default: gui


### PR DESCRIPTION
Set default to windows server 2022. Removed all sizes other than medium since that is all we support.  Set orb version to 4.2?